### PR TITLE
install wakatime button working for now only for vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-redux": "^7.1.0",
-    "react-with-styles": "^3.2.3",
+    "react-with-styles": "^4.0.1",
     "react-with-styles-interface-aphrodite": "^5.0.1",
     "readdirp": "^3.1.2",
     "redux": "^4.0.4",

--- a/src/components/ActiveEditors.tsx
+++ b/src/components/ActiveEditors.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
+
 import EditorIcon from "./EditorIcon";
 import { enableEditors } from '../actions/rendererActions';
 

--- a/src/components/ActiveEditors.tsx
+++ b/src/components/ActiveEditors.tsx
@@ -5,8 +5,11 @@ import { bindActionCreators } from "redux";
 
 import EditorIcon from "./EditorIcon";
 import { enableEditors } from '../actions/rendererActions';
+import { useStyles } from '../themes';
 
 const ActiveEditors = ({ editors, enableEditors }) => {
+
+  const { css, styles } = useStyles({ stylesFn });
 
   useEffect(() => {
     const fetchData = async () => {
@@ -22,7 +25,7 @@ const ActiveEditors = ({ editors, enableEditors }) => {
   }, []); // eslint-disable-line
 
   return (
-    <div>
+    <div {...css(styles.div)}>
       {editors.map(editor => (
         <EditorIcon {...editor} />
       ))}
@@ -35,6 +38,17 @@ ActiveEditors.propTypes = {
 ActiveEditors.defaultProps = {
   editors: []
 };
+
+const stylesFn = () => {
+  return ({
+    div: {
+      display: 'flex',
+      flexWrap: 'wrap',
+      justifyContent: 'center'
+    }
+  });
+}
+
 const mapStateToProps = ({ editors = [] }) => ({
   editors: editors.filter(e => e.enabled)
 });

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -5,7 +5,7 @@ import { withStyles } from "../themes";
 const Button = ({ enabled, text, styles, css, onClick }) => {
   return (
     <div
-      onClick={onClick}
+      onClick={() => enabled ? onClick() : console.log('disabled')}
       {...css(styles.wrapper, enabled ? styles.enabled : styles.disabled)}
     >
       {text}
@@ -21,18 +21,27 @@ Button.propTypes = {
   css: PropTypes.func
 };
 Button.defaultProps = {
+  enabled: true,
   styles: {},
   css: () => {}
 };
 export default withStyles(() => ({
   wrapper: {
-    textAlign: "center",
-    border: "1px solid #947777",
-    width: "fit-content",
-    padding: "0.3em 0.8em",
-    borderRadius: "3px",
     cursor: "pointer",
-    userSelect: 'none'
+    userSelect: 'none',
+    display: 'inline-block',
+    fontWeight: 400,
+    textAlign: 'center',
+    verticalAlign: 'middle',
+    border: '1px solid transparent',
+    padding: '.375rem .75rem',
+    fontSize: '1rem',
+    lineHeight: '1.5',
+    borderRadius: '.25rem',
+    transition: 'color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out',
+    color: '#fff',
+    backgroundColor: '#17a2b8',
+    borderColor: '#17a2b8'
   },
   enabled: {
     opacity: 1

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "../themes";
+import { useStyles } from "../themes";
 
-const Button = ({ enabled, text, styles, css, onClick }) => {
+const Button = ({ enabled, text, onClick }) => {
+
+  const { css, styles } = useStyles({ stylesFn });
+
   return (
     <div
       onClick={() => enabled ? onClick() : console.log('disabled')}
@@ -17,36 +20,42 @@ Button.propTypes = {
   onClick: PropTypes.func,
   enabled: PropTypes.bool,
   text: PropTypes.string.isRequired,
-  styles: PropTypes.object,
-  css: PropTypes.func
 };
+
 Button.defaultProps = {
-  enabled: true,
-  styles: {},
-  css: () => {}
+  enabled: true
 };
-export default withStyles(() => ({
-  wrapper: {
-    cursor: "pointer",
-    userSelect: 'none',
-    display: 'inline-block',
-    fontWeight: 400,
-    textAlign: 'center',
-    verticalAlign: 'middle',
-    border: '1px solid transparent',
-    padding: '.375rem .75rem',
-    fontSize: '1rem',
-    lineHeight: '1.5',
-    borderRadius: '.25rem',
-    transition: 'color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out',
-    color: '#fff',
-    backgroundColor: '#17a2b8',
-    borderColor: '#17a2b8'
-  },
-  enabled: {
-    opacity: 1
-  },
-  disabled: {
-    opacity: 0.6
-  }
-}))(Button);
+
+const stylesFn = () => {
+  return ({
+    wrapper: {
+      cursor: "pointer",
+      userSelect: 'none',
+      display: 'inline-block',
+      fontWeight: 400,
+      textAlign: 'center',
+      verticalAlign: 'middle',
+      border: '1px solid transparent',
+      padding: '.375rem .75rem',
+      fontSize: '1rem',
+      lineHeight: '1.5',
+      borderRadius: '.25rem',
+      transition: 'color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out',
+      color: '#fff',
+      backgroundColor: '#17a2b8',
+      borderColor: '#17a2b8',
+      ':hover': {
+        backgroundColor: '#138496',
+        borderColor: '#117a8b'
+      }
+    },
+    enabled: {
+      opacity: 1
+    },
+    disabled: {
+      opacity: 0.6
+    }
+  });
+}
+
+export default Button;

--- a/src/components/EditorIcon.tsx
+++ b/src/components/EditorIcon.tsx
@@ -39,7 +39,8 @@ export default withStyles(() => ({
     width: "auto",
     height: "20vw",
     maxHeight: 128,
-    minHeight: 48
+    minHeight: 48,
+    margin: '.5rem'
   },
   enabled: {
     opacity: 1

--- a/src/components/InstallEditors.tsx
+++ b/src/components/InstallEditors.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react'
+import { connect } from "react-redux";
+
+import Button from './Button';
+
+const InstallEditors = ({ editors }) => {
+  
+  const [installing, setInstalling] = useState(false);
+  const [uninstalling, setUninstalling] = useState(false);
+
+  /**
+   * Install Wakatime plugin on all available editors in the system
+   */
+  const installAllEditors = async () => {
+    setInstalling(true);
+    for (const editor of editors) {
+      if (editor.name === 'Visual Studio Code') {
+        await editor.instance.installPlugin();
+      }
+    };
+    setInstalling(false);
+  }
+
+  /**
+   * Uninstall Wakatime plugin on all available editors in the system
+   */
+  const uninstallAllEditors = async () => {
+    setUninstalling(true);
+    for (const editor of editors) {
+      if (editor.name === 'Visual Studio Code') {
+        await editor.instance.uninstallPlugin();
+      }
+    };
+    setUninstalling(false);
+  }
+
+  return (
+    <div>
+      <Button text="Install" onClick={installAllEditors} enabled={!installing} />
+      <Button text="UnInstall" onClick={uninstallAllEditors} enabled={!uninstalling} />
+    </div>
+  )
+}
+
+const mapStateToProps = ({ editors = [] }) => ({
+  editors: editors.filter(e => e.enabled)
+});
+
+export default connect(
+  mapStateToProps
+)(InstallEditors);

--- a/src/components/InstallEditors.tsx
+++ b/src/components/InstallEditors.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react'
 import { connect } from "react-redux";
 
+import { useStyles } from '../themes';
 import Button from './Button';
 
 const InstallEditors = ({ editors }) => {
-  
+
   const [installing, setInstalling] = useState(false);
-  const [uninstalling, setUninstalling] = useState(false);
+  const { css, styles } = useStyles({ stylesFn });
 
   /**
    * Install Wakatime plugin on all available editors in the system
@@ -21,25 +22,20 @@ const InstallEditors = ({ editors }) => {
     setInstalling(false);
   }
 
-  /**
-   * Uninstall Wakatime plugin on all available editors in the system
-   */
-  const uninstallAllEditors = async () => {
-    setUninstalling(true);
-    for (const editor of editors) {
-      if (editor.name === 'Visual Studio Code') {
-        await editor.instance.uninstallPlugin();
-      }
-    };
-    setUninstalling(false);
-  }
-
   return (
-    <div>
+    <div {...css(styles.div)}>
       <Button text="Install" onClick={installAllEditors} enabled={!installing} />
-      <Button text="UnInstall" onClick={uninstallAllEditors} enabled={!uninstalling} />
     </div>
   )
+}
+
+const stylesFn = () => {
+  return ({
+    div: {
+      marginBottom: '1rem',
+      textAlign: 'center'
+    }
+  });
 }
 
 const mapStateToProps = ({ editors = [] }) => ({

--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Provider } from "react-redux";
 import { render } from "react-dom";
 import ActiveEditors from "../components/ActiveEditors";
-import Button from "../components/Button";
+import InstallEditors from "../components/InstallEditors";
 import store from "../stores/rendererStore";
 import isMainProcess from "../utils/isMainProcess";
 
@@ -10,7 +10,7 @@ console.log("isMainProcess", isMainProcess);
 const div = document.getElementById("container");
 render(
   <Provider store={store}>
-    <Button text="Install" onClick={() => console.log('clicked!')}/>
+    <InstallEditors />
     <ActiveEditors />
   </Provider>,
   div

--- a/src/editors/vscode.ts
+++ b/src/editors/vscode.ts
@@ -44,14 +44,14 @@ export default class VsCode extends Editor {
 
   public async installPlugin(): Promise<void> {
     const { stdout, stderr } = await exec(
-      "code --install-extension WakaTime.vscode-wakatime"
+      "code --install-extension wakatime.vscode-wakatime"
     );
     if (stderr) return Promise.reject(new Error(stderr));
   }
 
   public async uninstallPlugin(): Promise<void> {
     const { stdout, stderr } = await exec(
-      "code --uninstall-extension WakaTime.vscode-wakatime"
+      "code --uninstall-extension wakatime.vscode-wakatime"
     );
     if (stderr) return Promise.reject(new Error(stderr));
   }

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,10 +1,11 @@
 import ThemedStyleSheet from "react-with-styles/lib/ThemedStyleSheet";
 import aphroditeInterface from "react-with-styles-interface-aphrodite";
 import { css, withStyles } from "react-with-styles";
+import useStyles from "react-with-styles/lib/hooks/useStyles";
 
 import MyTheme from "./defaultTheme";
 
 ThemedStyleSheet.registerTheme(MyTheme);
 ThemedStyleSheet.registerInterface(aphroditeInterface);
 
-export { css, withStyles, ThemedStyleSheet };
+export { css, withStyles, ThemedStyleSheet, useStyles };

--- a/yarn.lock
+++ b/yarn.lock
@@ -453,7 +453,7 @@ acorn@^6.0.7, acorn@^6.2.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.2.1.tgz#3ed8422d6dec09e6121cc7a843ca86a330a86b51"
   integrity sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==
 
-airbnb-prop-types@^2.8.1:
+airbnb-prop-types@^2.10.0, airbnb-prop-types@^2.14.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz#5287820043af1eb469f5b0af0d6f70da6c52aaef"
   integrity sha512-jUh2/hfKsRjNFC4XONQrxo/n/3GG4Tn6Hl0WlFQN5PY9OMC9loSCoAYKnZsWaP8wEfd5xcrPloK0Zg6iS1xwVA==
@@ -1920,7 +1920,7 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@^1.5.1:
+deepmerge@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
   integrity sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==
@@ -2065,7 +2065,7 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-direction@^1.0.1:
+direction@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/direction/-/direction-1.0.3.tgz#5030e1e091e923904067d015dbaafd08f4d27d26"
   integrity sha512-8bHRqMt4w/kND19KBksE4NOJo+gIOPuiZfxQvbd6xikfKbuNBYBdLIw0hA/4lWzBaDpwpW+Olmg1BjD9+0LU2w==
@@ -3558,11 +3558,6 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hoist-non-react-statics@^2.3.1:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
 hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0:
   version "3.3.0"
@@ -6079,7 +6074,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6265,19 +6260,19 @@ react-redux@^7.1.0:
     prop-types "^15.7.2"
     react-is "^16.8.6"
 
-react-with-direction@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/react-with-direction/-/react-with-direction-1.3.0.tgz#9885f5941aa986be753db95a41e8f3d8f8de97ff"
-  integrity sha512-2TflEebNckTNUybw3Rzqjg4BwM/H380ZL5lsbZ5f4UTY2JyE5uQdQZK5T2w+BDJSAMcqoA2RDJYa4e7Cl6C2Kg==
+react-with-direction@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-with-direction/-/react-with-direction-1.3.1.tgz#9fd414564f0ffe6947e5ff176f6132dd83f8b8df"
+  integrity sha512-aGcM21ZzhqeXFvDCfPj0rVNYuaVXfTz5D3Rbn0QMz/unZe+CCiLHthrjQWO7s6qdfXORgYFtmS7OVsRgSk5LXQ==
   dependencies:
-    airbnb-prop-types "^2.8.1"
+    airbnb-prop-types "^2.10.0"
     brcast "^2.0.2"
-    deepmerge "^1.5.1"
-    direction "^1.0.1"
-    hoist-non-react-statics "^2.3.1"
+    deepmerge "^1.5.2"
+    direction "^1.0.2"
+    hoist-non-react-statics "^3.3.0"
     object.assign "^4.1.0"
     object.values "^1.0.4"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
 
 react-with-styles-interface-aphrodite@^5.0.1:
   version "5.0.1"
@@ -6290,15 +6285,16 @@ react-with-styles-interface-aphrodite@^5.0.1:
     object.entries "^1.0.4"
     rtl-css-js "^1.10.0"
 
-react-with-styles@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/react-with-styles/-/react-with-styles-3.2.3.tgz#b058584065bb36c0d80ccc911725492692db8a61"
-  integrity sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==
+react-with-styles@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-with-styles/-/react-with-styles-4.0.1.tgz#22b5170d39769b643dd650cc183e9419650af12d"
+  integrity sha512-J77k4E2Dcm4SpfbQEet2KyRjZJtPCWD1PVkOB5vIOJewg/VEIMkb2MVVxusLTh1nwtfo7cnxY6gHytF6NcBkLQ==
   dependencies:
+    airbnb-prop-types "^2.14.0"
     hoist-non-react-statics "^3.2.1"
     object.assign "^4.1.0"
-    prop-types "^15.6.2"
-    react-with-direction "^1.3.0"
+    prop-types "^15.7.2"
+    react-with-direction "^1.3.1"
 
 react@^16.8.6:
   version "16.8.6"


### PR DESCRIPTION
**Dont merge before https://github.com/wakatime/desktop/pull/49**

* Install button for global installation of wakatime plugin on all available editors in the system (right now only works for vscode)
* Added as well a uninstall button just in case, if needed we can easily remove it
* use useStyles hook from react-with-styles

[x] test pass